### PR TITLE
More private dns resources

### DIFF
--- a/examples/apply_main.tf
+++ b/examples/apply_main.tf
@@ -58,6 +58,43 @@ module "dns" {
       }
     }
   }
+  private_dns_a_record = {
+    "@" = {
+      resource_group_name = module.dns.private_dns_zone["mms-github-privat-plattform.com"].resource_group_name
+      zone_name           = module.dns.private_dns_zone["mms-github-privat-plattform.com"].name
+      records             = ["127.0.0.3"]
+    }
+  }
+  private_dns_cname_record = {
+    www = {
+      resource_group_name = module.dns.private_dns_zone["mms-github-privat-plattform.com"].resource_group_name
+      zone_name           = module.dns.private_dns_zone["mms-github-privat-plattform.com"].name
+      record              = module.dns.private_dns_a_record["@"].fqdn
+    }
+  }
+  private_dns_txt_record = {
+    dnsauth = {
+      resource_group_name = module.dns.private_dns_zone["mms-github-privat-plattform.com"].resource_group_name
+      zone_name           = module.dns.private_dns_zone["mms-github-privat-plattform.com"].name
+      record = {
+        frontdoor = {
+          value = "frontdoor"
+        }
+      }
+    }
+  }
+  private_dns_mx_record = {
+    mail = {
+      resource_group_name = module.dns.private_dns_zone["mms-github-privat-plattform.com"].resource_group_name
+      zone_name           = module.dns.private_dns_zone["mms-github-privat-plattform.com"].name
+      record = {
+        mail1 = {
+          preference = 10
+          exchange   = "mail1.telekom-mms.com"
+        }
+      }
+    }
+  }
   private_dns_zone_virtual_network_link = {
     pl-mms-github = {
       resource_group_name   = "rg-mms-github"

--- a/examples/full_main.tf
+++ b/examples/full_main.tf
@@ -98,6 +98,67 @@ module "dns" {
       }
     }
   }
+  private_dns_a_record = {
+    "@" = {
+      resource_group_name = module.dns.private_dns_zone["mms-github-privat-plattform.com"].resource_group_name
+      zone_name           = module.dns.private_dns_zone["mms-github-privat-plattform.com"].name
+      records             = ["127.0.0.3"]
+      tags = {
+        project     = "mms-github"
+        environment = terraform.workspace
+        managed-by  = "terraform"
+      }
+    }
+  }
+  private_dns_cname_record = {
+    www = {
+      resource_group_name = module.dns.private_dns_zone["mms-github-privat-plattform.com"].resource_group_name
+      zone_name           = module.dns.private_dns_zone["mms-github-privat-plattform.com"].name
+      record              = module.dns.private_dns_a_record["@"].fqdn
+      tags = {
+        project     = "mms-github"
+        environment = terraform.workspace
+        managed-by  = "terraform"
+      }
+    }
+  }
+  private_dns_txt_record = {
+    dnsauth = {
+      resource_group_name = module.dns.private_dns_zone["mms-github-privat-plattform.com"].resource_group_name
+      zone_name           = module.dns.private_dns_zone["mms-github-privat-plattform.com"].name
+      record = {
+        frontdoor = {
+          value = "frontdoor"
+        }
+      }
+      tags = {
+        project     = "mms-github"
+        environment = terraform.workspace
+        managed-by  = "terraform"
+      }
+    }
+  }
+  private_dns_mx_record = {
+    mail = {
+      resource_group_name = module.dns.private_dns_zone["mms-github-privat-plattform.com"].resource_group_name
+      zone_name           = module.dns.private_dns_zone["mms-github-privat-plattform.com"].name
+      record = {
+        mail1 = {
+          preference = 10
+          exchange   = "mail1.telekom-mms.com"
+        }
+        mail2 = {
+          preference = 20
+          exchange   = "mail2.telekom-mms.com"
+        }
+      }
+      tags = {
+        project     = "mms-github"
+        environment = terraform.workspace
+        managed-by  = "terraform"
+      }
+    }
+  }
   private_dns_zone_virtual_network_link = {
     pl-mms-github = {
       resource_group_name   = "rg-mms-github"

--- a/examples/min_main.tf
+++ b/examples/min_main.tf
@@ -58,6 +58,43 @@ module "dns" {
       }
     }
   }
+  private_dns_a_record = {
+    "@" = {
+      resource_group_name = module.dns.private_dns_zone["mms-github-privat-plattform.com"].resource_group_name
+      zone_name           = module.dns.private_dns_zone["mms-github-privat-plattform.com"].name
+      records             = ["127.0.0.3"]
+    }
+  }
+  private_dns_cname_record = {
+    www = {
+      resource_group_name = module.dns.private_dns_zone["mms-github-privat-plattform.com"].resource_group_name
+      zone_name           = module.dns.private_dns_zone["mms-github-privat-plattform.com"].name
+      record              = module.dns.private_dns_a_record["@"].fqdn
+    }
+  }
+  private_dns_txt_record = {
+    dnsauth = {
+      resource_group_name = module.dns.private_dns_zone["mms-github-privat-plattform.com"].resource_group_name
+      zone_name           = module.dns.private_dns_zone["mms-github-privat-plattform.com"].name
+      record = {
+        frontdoor = {
+          value = "frontdoor"
+        }
+      }
+    }
+  }
+  private_dns_mx_record = {
+    mail = {
+      resource_group_name = module.dns.private_dns_zone["mms-github-privat-plattform.com"].resource_group_name
+      zone_name           = module.dns.private_dns_zone["mms-github-privat-plattform.com"].name
+      record = {
+        mail1 = {
+          preference = 10
+          exchange   = "mail1.telekom-mms.com"
+        }
+      }
+    }
+  }
   private_dns_zone_virtual_network_link = {
     pl-mms-github = {
       resource_group_name   = "rg-mms-github"

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,9 @@
 /**
 * # dns
 *
-* This module manages the hashicorp/azurerm dns resources.
+* This module manages the hashicorp/azurerm dns and private dns resources.
 * For more information see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs > dns
+* and https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs > private dns
 *
 */
 
@@ -69,6 +70,18 @@ resource "azurerm_dns_a_record" "dns_a_record" {
   tags = local.dns_a_record[each.key].tags
 }
 
+resource "azurerm_private_dns_a_record" "private_dns_a_record" {
+  for_each = var.private_dns_a_record
+
+  name                = local.private_dns_a_record[each.key].name == "" ? each.key : local.private_dns_a_record[each.key].name
+  resource_group_name = local.private_dns_a_record[each.key].resource_group_name
+  zone_name           = local.private_dns_a_record[each.key].zone_name
+  ttl                 = local.private_dns_a_record[each.key].ttl
+  records             = local.private_dns_a_record[each.key].records
+
+  tags = local.private_dns_a_record[each.key].tags
+}
+
 resource "azurerm_dns_cname_record" "dns_cname_record" {
   for_each = var.dns_cname_record
 
@@ -80,6 +93,18 @@ resource "azurerm_dns_cname_record" "dns_cname_record" {
   target_resource_id  = local.dns_cname_record[each.key].target_resource_id
 
   tags = local.dns_cname_record[each.key].tags
+}
+
+resource "azurerm_private_dns_cname_record" "private_dns_cname_record" {
+  for_each = var.private_dns_cname_record
+
+  name                = local.private_dns_cname_record[each.key].name == "" ? each.key : local.private_dns_cname_record[each.key].name
+  resource_group_name = local.private_dns_cname_record[each.key].resource_group_name
+  zone_name           = local.private_dns_cname_record[each.key].zone_name
+  ttl                 = local.private_dns_cname_record[each.key].ttl
+  record              = local.private_dns_cname_record[each.key].record
+
+  tags = local.private_dns_cname_record[each.key].tags
 }
 
 resource "azurerm_dns_txt_record" "dns_txt_record" {
@@ -101,6 +126,25 @@ resource "azurerm_dns_txt_record" "dns_txt_record" {
   tags = local.dns_txt_record[each.key].tags
 }
 
+resource "azurerm_private_dns_txt_record" "private_dns_txt_record" {
+  for_each = var.private_dns_txt_record
+
+  name                = local.private_dns_txt_record[each.key].name == "" ? each.key : local.private_dns_txt_record[each.key].name
+  resource_group_name = local.private_dns_txt_record[each.key].resource_group_name
+  zone_name           = local.private_dns_txt_record[each.key].zone_name
+  ttl                 = local.private_dns_txt_record[each.key].ttl
+
+  dynamic "record" {
+    for_each = local.private_dns_txt_record[each.key].record
+
+    content {
+      value = local.private_dns_txt_record[each.key].record[record.key].value
+    }
+  }
+
+  tags = local.private_dns_txt_record[each.key].tags
+}
+
 resource "azurerm_dns_mx_record" "dns_mx_record" {
   for_each = var.dns_mx_record
 
@@ -119,6 +163,26 @@ resource "azurerm_dns_mx_record" "dns_mx_record" {
   }
 
   tags = local.dns_mx_record[each.key].tags
+}
+
+resource "azurerm_private_dns_mx_record" "private_dns_mx_record" {
+  for_each = var.private_dns_mx_record
+
+  name                = local.private_dns_mx_record[each.key].name == "" ? each.key : local.private_dns_mx_record[each.key].name
+  resource_group_name = local.private_dns_mx_record[each.key].resource_group_name
+  zone_name           = local.private_dns_mx_record[each.key].zone_name
+  ttl                 = local.private_dns_mx_record[each.key].ttl
+
+  dynamic "record" {
+    for_each = local.private_dns_mx_record[each.key].record
+
+    content {
+      preference = local.private_dns_mx_record[each.key].record[record.key].preference
+      exchange   = local.private_dns_mx_record[each.key].record[record.key].exchange
+    }
+  }
+
+  tags = local.private_dns_mx_record[each.key].tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "private_dns_zone_virtual_network_link" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,6 @@ output "dns_zone" {
     }
   }
 }
-
 output "private_dns_zone" {
   description = "Outputs all attributes of resource_type."
   value = {
@@ -30,6 +29,16 @@ output "dns_a_record" {
     }
   }
 }
+output "private_dns_a_record" {
+  description = "Outputs all attributes of resource_type."
+  value = {
+    for private_dns_a_record in keys(azurerm_private_dns_a_record.private_dns_a_record) :
+    private_dns_a_record => {
+      for key, value in azurerm_private_dns_a_record.private_dns_a_record[private_dns_a_record] :
+      key => value
+    }
+  }
+}
 
 output "dns_cname_record" {
   description = "Outputs all attributes of resource_type."
@@ -37,6 +46,16 @@ output "dns_cname_record" {
     for dns_cname_record in keys(azurerm_dns_cname_record.dns_cname_record) :
     dns_cname_record => {
       for key, value in azurerm_dns_cname_record.dns_cname_record[dns_cname_record] :
+      key => value
+    }
+  }
+}
+output "private_dns_cname_record" {
+  description = "Outputs all attributes of resource_type."
+  value = {
+    for private_dns_cname_record in keys(azurerm_private_dns_cname_record.private_dns_cname_record) :
+    private_dns_cname_record => {
+      for key, value in azurerm_private_dns_cname_record.private_dns_cname_record[private_dns_cname_record] :
       key => value
     }
   }
@@ -52,6 +71,16 @@ output "dns_txt_record" {
     }
   }
 }
+output "private_dns_txt_record" {
+  description = "Outputs all attributes of resource_type."
+  value = {
+    for private_dns_txt_record in keys(azurerm_private_dns_txt_record.private_dns_txt_record) :
+    private_dns_txt_record => {
+      for key, value in azurerm_private_dns_txt_record.private_dns_txt_record[private_dns_txt_record] :
+      key => value
+    }
+  }
+}
 
 output "dns_mx_record" {
   description = "Outputs all attributes of resource_type."
@@ -59,6 +88,16 @@ output "dns_mx_record" {
     for dns_mx_record in keys(azurerm_dns_mx_record.dns_mx_record) :
     dns_mx_record => {
       for key, value in azurerm_dns_mx_record.dns_mx_record[dns_mx_record] :
+      key => value
+    }
+  }
+}
+output "private_dns_mx_record" {
+  description = "Outputs all attributes of resource_type."
+  value = {
+    for private_dns_mx_record in keys(azurerm_private_dns_mx_record.private_dns_mx_record) :
+    private_dns_mx_record => {
+      for key, value in azurerm_private_dns_mx_record.private_dns_mx_record[private_dns_mx_record] :
       key => value
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,17 @@ variable "dns_a_record" {
   default     = {}
   description = "resource definition, default settings are defined within locals and merged with var settings"
 }
+variable "private_dns_a_record" {
+  type        = any
+  default     = {}
+  description = "resource definition, default settings are defined within locals and merged with var settings"
+}
 variable "dns_cname_record" {
+  type        = any
+  default     = {}
+  description = "resource definition, default settings are defined within locals and merged with var settings"
+}
+variable "private_dns_cname_record" {
   type        = any
   default     = {}
   description = "resource definition, default settings are defined within locals and merged with var settings"
@@ -23,7 +33,17 @@ variable "dns_txt_record" {
   default     = {}
   description = "resource definition, default settings are defined within locals and merged with var settings"
 }
+variable "private_dns_txt_record" {
+  type        = any
+  default     = {}
+  description = "resource definition, default settings are defined within locals and merged with var settings"
+}
 variable "dns_mx_record" {
+  type        = any
+  default     = {}
+  description = "resource definition, default settings are defined within locals and merged with var settings"
+}
+variable "private_dns_mx_record" {
   type        = any
   default     = {}
   description = "resource definition, default settings are defined within locals and merged with var settings"
@@ -72,6 +92,12 @@ locals {
       target_resource_id = null
       tags               = {}
     }
+    private_dns_a_record = {
+      name    = ""
+      ttl     = 3600 // define default
+      records = null
+      tags    = {}
+    }
     dns_cname_record = {
       name               = ""
       ttl                = 3600 // define default
@@ -79,12 +105,28 @@ locals {
       target_resource_id = null
       tags               = {}
     }
+    private_dns_cname_record = {
+      name   = ""
+      ttl    = 3600 // define default
+      record = null
+      tags   = {}
+    }
     dns_txt_record = {
       name = ""
       ttl  = 3600 // define default
       tags = {}
     }
+    private_dns_txt_record = {
+      name = ""
+      ttl  = 3600 // define default
+      tags = {}
+    }
     dns_mx_record = {
+      name = ""
+      ttl  = 3600 // define default
+      tags = {}
+    }
+    private_dns_mx_record = {
       name = ""
       ttl  = 3600 // define default
       tags = {}
@@ -131,17 +173,33 @@ locals {
     for dns_a_record in keys(var.dns_a_record) :
     dns_a_record => merge(local.default.dns_a_record, var.dns_a_record[dns_a_record])
   }
+  private_dns_a_record = {
+    for private_dns_a_record in keys(var.private_dns_a_record) :
+    private_dns_a_record => merge(local.default.private_dns_a_record, var.private_dns_a_record[private_dns_a_record])
+  }
   dns_cname_record = {
     for dns_cname_record in keys(var.dns_cname_record) :
     dns_cname_record => merge(local.default.dns_cname_record, var.dns_cname_record[dns_cname_record])
+  }
+  private_dns_cname_record = {
+    for private_dns_cname_record in keys(var.private_dns_cname_record) :
+    private_dns_cname_record => merge(local.default.private_dns_cname_record, var.private_dns_cname_record[private_dns_cname_record])
   }
   dns_txt_record = {
     for dns_txt_record in keys(var.dns_txt_record) :
     dns_txt_record => merge(local.default.dns_txt_record, var.dns_txt_record[dns_txt_record])
   }
+  private_dns_txt_record = {
+    for private_dns_txt_record in keys(var.private_dns_txt_record) :
+    private_dns_txt_record => merge(local.default.private_dns_txt_record, var.private_dns_txt_record[private_dns_txt_record])
+  }
   dns_mx_record = {
     for dns_mx_record in keys(var.dns_mx_record) :
     dns_mx_record => merge(local.default.dns_mx_record, var.dns_mx_record[dns_mx_record])
+  }
+  private_dns_mx_record = {
+    for private_dns_mx_record in keys(var.private_dns_mx_record) :
+    private_dns_mx_record => merge(local.default.private_dns_mx_record, var.private_dns_mx_record[private_dns_mx_record])
   }
   private_dns_zone_virtual_network_link = {
     for private_dns_zone_virtual_network_link in keys(var.private_dns_zone_virtual_network_link) :


### PR DESCRIPTION
The following private dns resources can now be managed with tis module:
- azurerm_private_dns_a_record (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record)
- azurerm_private_dns_cname_record (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_cname_record)
- azurerm_private_dns_txt_record (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_txt_record)
- azurerm_private_dns_mx_record (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_mx_record)
